### PR TITLE
Added tests for relational operations and fixed the tokenization of \n at the end of files

### DIFF
--- a/language/parser/src/parser/code_parser.rs
+++ b/language/parser/src/parser/code_parser.rs
@@ -137,7 +137,7 @@ pub fn parse_line(parser_utils: &mut ParserUtils, state: ParseState)
                     //Skip because ParenOpen handles this.
                 } else if let TokenTypes::Operator = next.token_type {
                     //Skip if a generic method is being called next to preserve the last effect.
-                     if isGeneric(&token, parser_utils) {
+                     if is_generic(&token, parser_utils) {
                          continue
                      } else {
                         effect = Some(
@@ -238,7 +238,7 @@ pub fn parse_line(parser_utils: &mut ParserUtils, state: ParseState)
                 let last = parser_utils.tokens.get(parser_utils.index - 2).unwrap();
                 // If there is a variable right next to a less than, it's probably a generic method call.
                 // Example: test<Value>()
-                if (last.token_type == TokenTypes::Variable || last.token_type == TokenTypes::CallingType) && isGeneric(&token, parser_utils){
+                if (last.token_type == TokenTypes::Variable || last.token_type == TokenTypes::CallingType) && is_generic(&token, parser_utils){
                      effect = Some(parse_generic_method(effect, parser_utils)?);
                  } else {
                     let operator = parse_operator(effect, parser_utils, &state)?;
@@ -254,7 +254,7 @@ pub fn parse_line(parser_utils: &mut ParserUtils, state: ParseState)
             TokenTypes::ArgumentEnd => break,
             TokenTypes::CallingType => {
                 let next: &Token = parser_utils.tokens.get(parser_utils.index).unwrap();
-                if next.token_type == TokenTypes::ParenOpen || isGeneric(&token, parser_utils){
+                if next.token_type == TokenTypes::ParenOpen || is_generic(&token, parser_utils){
                          // Ignored, ParenOpen or Operator handles this
                 } else {
                     if effect.is_none() {
@@ -476,7 +476,7 @@ fn parse_new_args(parser_utils: &mut ParserUtils) -> Result<Vec<(String, Effects
 // Supposed to replace this check: if next.to_string(parser_utils.buffer) == "<" &&
                     //token.to_string(parser_utils.buffer).bytes().last().unwrap() != b' '
 // to allow for relational operators such as "<" or "<="
-fn isGeneric(token: &Token, parser_utils: &ParserUtils) -> bool{
+fn is_generic(token: &Token, parser_utils: &ParserUtils) -> bool{
     let next: &Token = parser_utils.tokens.get(parser_utils.index).unwrap();
 
     // TODO

--- a/language/parser/src/parser/code_parser.rs
+++ b/language/parser/src/parser/code_parser.rs
@@ -472,10 +472,6 @@ fn parse_new_args(parser_utils: &mut ParserUtils) -> Result<Vec<(String, Effects
     return Ok(values);
 }
 
-
-// Supposed to replace this check: if next.to_string(parser_utils.buffer) == "<" &&
-                    //token.to_string(parser_utils.buffer).bytes().last().unwrap() != b' '
-// to allow for relational operators such as "<" or "<="
 fn is_generic(token: &Token, parser_utils: &ParserUtils) -> bool{
     let next: &Token = parser_utils.tokens.get(parser_utils.index).unwrap();
 

--- a/language/parser/src/tokens/tokens.rs
+++ b/language/parser/src/tokens/tokens.rs
@@ -165,5 +165,6 @@ pub enum TokenTypes {
     GenericBoundEnd = 67,
     GenericsEnd = 68,
     Do = 69,
-    Char = 70
+    Char = 70,
+    BlankLine = 71
 }

--- a/language/parser/src/tokens/top_tokenizer.rs
+++ b/language/parser/src/tokens/top_tokenizer.rs
@@ -70,9 +70,7 @@ pub fn next_top_token(tokenizer: &mut Tokenizer) -> Token {
             // Looking for a field name inside a struct
             parse_to_character(tokenizer, TokenTypes::FieldName, &[b':', b'='])
         } else if tokenizer.state == TokenizerState::TOP_ELEMENT && tokenizer.matches("")  {
-            // If there are blank lines after all of the elements, skip them
-          
-            println!("hi");
+            // If there are blank lines after all of the modifiers at the EOF, ignore them
             tokenizer.index += 1;
             tokenizer.make_token(TokenTypes::BlankLine)
         } else {

--- a/language/parser/src/tokens/top_tokenizer.rs
+++ b/language/parser/src/tokens/top_tokenizer.rs
@@ -69,6 +69,12 @@ pub fn next_top_token(tokenizer: &mut Tokenizer) -> Token {
         } else if tokenizer.state == TokenizerState::TOP_ELEMENT_TO_STRUCT {
             // Looking for a field name inside a struct
             parse_to_character(tokenizer, TokenTypes::FieldName, &[b':', b'='])
+        } else if tokenizer.state == TokenizerState::TOP_ELEMENT && tokenizer.matches("")  {
+            // If there are blank lines after all of the elements, skip them
+          
+            println!("hi");
+            tokenizer.index += 1;
+            tokenizer.make_token(TokenTypes::BlankLine)
         } else {
             tokenizer.handle_invalid()
         },

--- a/lib/core/src/numbers.rv
+++ b/lib/core/src/numbers.rv
@@ -1,3 +1,5 @@
+import numbers::Match;
+
 //A trait for every primitive number type.
 pub trait Number {}
 
@@ -33,5 +35,15 @@ trait Cast<T> {
 pub internal impl<T: Number, E: Number> Cast<T> for E {
     pub fn cast(self) -> T {
 
+    }
+}
+
+trait Match{
+    fn matches(self, other) -> bool;
+}
+
+pub impl Match for Number {
+    pub fn matches(self, other: Number) -> bool {
+        return true;
     }
 }

--- a/lib/test/src/main.rv
+++ b/lib/test/src/main.rv
@@ -1,5 +1,13 @@
+import numbers::Match;
 import stdio;
 
 fn main() {
-    // Write your code here
+    let x = 0;
+    let y = 5;
+    if(x.matches(y)){
+        printf("hello world");
+    }
+    else{
+        printf("nothing?");
+    }
 }

--- a/lib/test/test/relational-operators.rv
+++ b/lib/test/test/relational-operators.rv
@@ -5,7 +5,7 @@ fn test() -> bool {
             return false;
         }
         if (val < 6){
-            return false
+            return false;
         } 
         if (val <= 6) {
             if (val > 1) {

--- a/lib/test/test/relational-operators.rv
+++ b/lib/test/test/relational-operators.rv
@@ -1,0 +1,18 @@
+fn test() -> bool {
+    let val = 6;
+    if (val >= 5) {
+        if (val > 10){
+            return false;
+        }
+        if (val < 6){
+            return false
+        } 
+        if (val <= 6) {
+            if (val > 1) {
+                return true;
+            }
+        }
+    }
+    return false;
+ 
+ }

--- a/lib/test/test/relational-operators.rv
+++ b/lib/test/test/relational-operators.rv
@@ -1,18 +1,73 @@
 fn test() -> bool {
-    let val = 6;
-    if (val >= 5) {
-        if (val > 10){
-            return false;
-        }
-        if (val < 6){
-            return false;
-        } 
-        if (val <= 6) {
-            if (val > 1) {
-                return true;
+    if(test_greater()){
+        if(test_less()){
+            if(test_greater_or_eq()){
+                if(test_less_or_eq()){
+                    return true;
+                }
             }
         }
     }
     return false;
  
  }
+
+fn test_greater() -> bool {
+    let x = 5;
+    if(x > 5){
+        return false;
+    }
+    if(x > 10){
+        return false;
+    }
+    if(x > 0){
+        return true;
+    }
+    return false;
+}
+
+
+fn test_less() -> bool {
+    let x = 5;
+    if(x < 5){
+        return false;
+    }
+    if(x < 0){
+        return false;
+    }
+    if(x < 10){
+        return true;
+    }
+    return false;
+}
+
+
+fn test_less_or_eq() -> bool {
+    let x = 5;
+    
+    if(x <= 0){
+        return false;
+    }
+    if(x <= 10){
+        if(x <= 5) {
+            return true;
+        }
+        return false;
+    }
+    return false;
+}
+
+fn test_greater_or_eq() -> bool {
+    let x = 5;
+    
+    if(x >= 10){
+        return false;
+    }
+    if(x >= 0){
+        if(x >= 5) {
+            return true;
+        }
+        return false;
+    }
+    return false;
+}


### PR DESCRIPTION
There was a bug that whenever there were blank lines at the end of the file, the tokenizer would create an error.  Now this shouldn't be the case. 