### PR TITLE
Allow trailing commas in new expressions

### DIFF
--- a/language/parser/src/parser/code_parser.rs
+++ b/language/parser/src/parser/code_parser.rs
@@ -39,6 +39,8 @@ pub enum ParseState {
     InOperator,
     // When inside both an operator and control variable.
     ControlOperator,
+    // When inside a new expression.
+    New
 }
 
 pub fn parse_line(parser_utils: &mut ParserUtils, state: ParseState)
@@ -123,6 +125,9 @@ pub fn parse_line(parser_utils: &mut ParserUtils, state: ParseState)
                 effect = Some(parse_string(parser_utils)?)
             }
             TokenTypes::LineEnd | TokenTypes::ParenClose => break,
+            TokenTypes::BlockEnd if state == ParseState::New => {
+                break;
+            }
             TokenTypes::CodeEnd | TokenTypes::BlockEnd => {
                 if effect.is_some() {
                     return Err(token.make_error(parser_utils.file.clone(),
@@ -452,7 +457,7 @@ fn parse_new_args(parser_utils: &mut ParserUtils) -> Result<Vec<(String, Effects
             TokenTypes::Colon | TokenTypes::ArgumentEnd => {
                 let effect = if let TokenTypes::Colon = token.token_type {
                     let token = token.clone();
-                    match parse_line(parser_utils, ParseState::None)? {
+                    match parse_line(parser_utils, ParseState::New)? {
                         Some(inner) => inner.effect,
                         None => return Err(token.make_error(parser_utils.file.clone(), format!("Expected effect!")))
                     }
@@ -463,10 +468,17 @@ fn parse_new_args(parser_utils: &mut ParserUtils) -> Result<Vec<(String, Effects
                 name = String::new();
             }
             TokenTypes::BlockEnd => break,
+            TokenTypes::LineEnd => {
+                if parser_utils.tokens.get(parser_utils.index - 2).unwrap().token_type == TokenTypes::BlockEnd {
+                    parser_utils.index -= 1;
+                    break;
+                }
+            }
             TokenTypes::InvalidCharacters => {}
             TokenTypes::Comment => {}
             _ => panic!("How'd you get here? {:?}", token.token_type)
         }
+
     }
 
     return Ok(values);


### PR DESCRIPTION
I think I solved this issue:

The functions in `language/parser/src/parser/code_parser.rs` get a little too eager and can advance the parser's cursor even if nothing gets parsed. The result is that omitting a comma after arguments in a `new` expression will cause the parser to land on the semicolon at the end of the `new` expression, and **not** the closing culry brace.

A somewhat hacky, but effective solution is to check if the parser did indeed get too eager by checking if the cursor does land on the semicolon, and if so, moves the cursor backward so that it points to the closing curly brace instead.

Closes #18.